### PR TITLE
custom fee distribution logic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -328,7 +328,7 @@ func NewMarsApp(
 		keys[banktypes.StoreKey],
 		app.AccountKeeper,
 		getSubspace(app, banktypes.ModuleName),
-		app.ModuleAccountAddrs(),
+		getBlockedModuleAccountAddrs(app), // NOTE: fee collector is excluded from blocked addresses
 	)
 	app.CrisisKeeper = crisiskeeper.NewKeeper(
 		getSubspace(app, crisistypes.ModuleName),
@@ -717,10 +717,19 @@ func getEnabledProposals() []wasm.ProposalType {
 	return proposals
 }
 
+// getBlockedModuleAccountAddrs returns all the app's blocked module account addresses
+//
+// forked from: https://github.com/cosmos/gaia/pull/1493/files
+func getBlockedModuleAccountAddrs(app *MarsApp) map[string]bool {
+	modAccAddrs := app.ModuleAccountAddrs()
+
+	delete(modAccAddrs, authtypes.NewModuleAddress(authtypes.FeeCollectorName).String())
+
+	return modAccAddrs
+}
+
 // initializes params keeper and its subspaces
-func initParamsKeeper(
-	codec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey sdk.StoreKey,
-) paramskeeper.Keeper {
+func initParamsKeeper(codec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey sdk.StoreKey) paramskeeper.Keeper {
 	paramsKeeper := paramskeeper.NewKeeper(codec, legacyAmino, key, tkey)
 
 	paramsKeeper.Subspace(authtypes.ModuleName)

--- a/app/app.go
+++ b/app/app.go
@@ -366,7 +366,7 @@ func NewMarsApp(
 		app.BankKeeper,
 		&stakingKeeper,
 		authtypes.FeeCollectorName,
-		app.ModuleAccountAddrs(),
+		app.ModuleAccountAddrs(), // we unblock fee collector in bank keeper, but keep blocking it here
 	)
 	app.SlashingKeeper = slashingkeeper.NewKeeper(
 		codec,

--- a/app/app.go
+++ b/app/app.go
@@ -719,7 +719,7 @@ func getEnabledProposals() []wasm.ProposalType {
 
 // getBlockedModuleAccountAddrs returns all the app's blocked module account addresses
 //
-// forked from: https://github.com/cosmos/gaia/pull/1493/files
+// forked from: https://github.com/cosmos/gaia/pull/1493
 func getBlockedModuleAccountAddrs(app *MarsApp) map[string]bool {
 	modAccAddrs := app.ModuleAccountAddrs()
 

--- a/app/wasm/msg_plugin.go
+++ b/app/wasm/msg_plugin.go
@@ -11,9 +11,11 @@ import (
 
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+
+	customdistrkeeper "github.com/mars-protocol/hub/custom/distribution/keeper"
 )
 
-func CustomMessageDecorator(distrKeeper *distrkeeper.Keeper) func(wasmkeeper.Messenger) wasmkeeper.Messenger {
+func CustomMessageDecorator(distrKeeper *customdistrkeeper.Keeper) func(wasmkeeper.Messenger) wasmkeeper.Messenger {
 	return func(old wasmkeeper.Messenger) wasmkeeper.Messenger {
 		return &CustomMessenger{
 			wrapped:     old,
@@ -24,7 +26,7 @@ func CustomMessageDecorator(distrKeeper *distrkeeper.Keeper) func(wasmkeeper.Mes
 
 type CustomMessenger struct {
 	wrapped     wasmkeeper.Messenger
-	distrKeeper *distrkeeper.Keeper
+	distrKeeper *customdistrkeeper.Keeper
 }
 
 // CustomKeeper must implement the `wasmkeeper.Messenger` interface
@@ -50,9 +52,10 @@ func (m *CustomMessenger) DispatchMsg(
 }
 
 func fundCommunityPool(
-	ctx sdk.Context, k *distrkeeper.Keeper, contractAddr sdk.AccAddress, fundCommunityPool *FundCommunityPool,
+	ctx sdk.Context, k *customdistrkeeper.Keeper, contractAddr sdk.AccAddress,
+	fundCommunityPool *FundCommunityPool,
 ) ([]sdk.Event, [][]byte, error) {
-	msgServer := distrkeeper.NewMsgServerImpl(*k)
+	msgServer := distrkeeper.NewMsgServerImpl(k.Keeper)
 
 	msg := &distrtypes.MsgFundCommunityPool{
 		Amount:    fundCommunityPool.Amount,

--- a/app/wasm/wasm.go
+++ b/app/wasm/wasm.go
@@ -4,10 +4,10 @@ import (
 	wasm "github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 
-	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	customdistrkeeper "github.com/mars-protocol/hub/custom/distribution/keeper"
 )
 
-func RegisterCustomPlugins(distrKeeper *distrkeeper.Keeper) []wasm.Option {
+func RegisterCustomPlugins(distrKeeper *customdistrkeeper.Keeper) []wasm.Option {
 	messengerDecoratorOpt := wasmkeeper.WithMessageHandlerDecorator(
 		CustomMessageDecorator(distrKeeper),
 	)

--- a/custom/distribution/README.md
+++ b/custom/distribution/README.md
@@ -1,3 +1,5 @@
 # Custom Distr
 
 The `customdistr` module is wrapper around Cosmos SDK's vanilla `distribution` module, inheriting most of its functionalities, but replacing the fee distribution logic with our custom implementation.
+
+For details, see the description of [this PR](https://github.com/mars-protocol/hub/pull/4).

--- a/custom/distribution/README.md
+++ b/custom/distribution/README.md
@@ -1,0 +1,3 @@
+# Custom Distr
+
+The `customdistr` module is wrapper around Cosmos SDK's vanilla `distribution` module, inheriting most of its functionalities, but replacing the fee distribution logic with our custom implementation.

--- a/custom/distribution/abci.go
+++ b/custom/distribution/abci.go
@@ -1,0 +1,42 @@
+package distribution
+
+import (
+	"time"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+
+	"github.com/mars-protocol/hub/custom/distribution/keeper"
+)
+
+// BeginBlocker sets the proposer for determining distribution during endblock and distribute rewards
+// for the previous block
+func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(distrtypes.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
+	// determine the total power signing the block
+	var previousTotalPower, sumPreviousPrecommitPower int64
+	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
+		previousTotalPower += voteInfo.Validator.Power
+		if voteInfo.SignedLastBlock {
+			sumPreviousPrecommitPower += voteInfo.Validator.Power
+		}
+	}
+
+	// TODO this is Tendermint-dependent
+	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
+	if ctx.BlockHeight() > 1 {
+		previousProposer := k.GetPreviousProposerConsAddr(ctx)
+
+		// NOTE: this `AllocateTokens` is our custom implementation, which overrides the vanilla one
+		k.AllocateTokens(ctx, sumPreviousPrecommitPower, previousTotalPower, previousProposer, req.LastCommitInfo.GetVotes())
+	}
+
+	// record the proposer for when we payout on the next block
+	consAddr := sdk.ConsAddress(req.Header.ProposerAddress)
+	k.SetPreviousProposerConsAddr(ctx, consAddr)
+}

--- a/custom/distribution/keeper/allocation.go
+++ b/custom/distribution/keeper/allocation.go
@@ -1,0 +1,45 @@
+package keeper
+
+import (
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/mars-protocol/hub/custom/distribution/types"
+)
+
+// AllocateTokens handles the distribution of fees collected in the previous block
+//
+// bondedVotes is a list of {validator address, validator voted on last block flag} tuple for all
+// validators in the bonded set.
+//
+// NOTE: this function not super optimized, as `k.authKeeper.GetModuleAccount` and `k.bankKeeper.GetAllBalances`
+// are invoked twice both here and in `k.Keeper.AllocateTokens`. however at this time i consider it
+// not worth to modify the whole function just to optimize this little bit
+func (k Keeper) AllocateTokens(
+	ctx sdk.Context, sumPreviousPrecommitPower, totalPreviousPower int64,
+	previousProposer sdk.ConsAddress, bondedVotes []abci.VoteInfo,
+) {
+	// fetch and clear the collected fees for distribution
+	//
+	// since this is called in BeginBlock, collected fees will be from the previous block, and
+	// distributed to the previous proposer
+	feeCollector := k.authKeeper.GetModuleAccount(ctx, k.feeCollectorName)
+	feesCollected := k.bankKeeper.GetAllBalances(ctx, feeCollector.GetAddress())
+
+	feesCollectedRewardDenom := sdk.NewCoin(types.RewardDenom, feesCollected.AmountOf(types.RewardDenom))
+	feesCollectedNonRewardDenom := feesCollected.Sub(sdk.NewCoins(feesCollectedRewardDenom))
+
+	// fees that are NOT in the reward denom go directly to the community pool
+	k.FundCommunityPool(ctx, feesCollectedNonRewardDenom, feeCollector.GetAddress())
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeSafetyFund,
+			sdk.NewAttribute(sdk.AttributeKeyAmount, feesCollectedNonRewardDenom.String()),
+		),
+	)
+
+	// for fees collected in the reward denom, we simply forward them to the vanilla `AllocateTokens` method
+	k.Keeper.AllocateTokens(ctx, sumPreviousPrecommitPower, totalPreviousPower, previousProposer, bondedVotes)
+}

--- a/custom/distribution/keeper/allocation.go
+++ b/custom/distribution/keeper/allocation.go
@@ -29,18 +29,18 @@ func (k Keeper) AllocateTokens(
 	feeCollector := k.authKeeper.GetModuleAccount(ctx, k.feeCollectorName)
 	feesCollected := k.bankKeeper.GetAllBalances(ctx, feeCollector.GetAddress())
 
-	feesCollectedRewardDenom := sdk.NewCoin(types.RewardDenom, feesCollected.AmountOf(types.RewardDenom))
-	feesCollectedNonRewardDenom := feesCollected.Sub(sdk.NewCoins(feesCollectedRewardDenom))
+	feesCollectedReward := sdk.NewCoin(types.RewardDenom, feesCollected.AmountOf(types.RewardDenom))
+	feesCollectedNonReward := feesCollected.Sub(sdk.NewCoins(feesCollectedReward))
 
-	// fees that are NOT in the reward denom go directly to the community pool
-	if err := k.FundCommunityPool(ctx, feesCollectedNonRewardDenom, feeCollector.GetAddress()); err != nil {
+	// fees that are NOT of the reward denom go directly to the community pool
+	if err := k.FundCommunityPool(ctx, feesCollectedNonReward, feeCollector.GetAddress()); err != nil {
 		panic(fmt.Sprintf("failed to fund community pool with non-mars tokens: %s", err))
 	}
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeSafetyFund,
-			sdk.NewAttribute(sdk.AttributeKeyAmount, feesCollectedNonRewardDenom.String()),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, feesCollectedNonReward.String()),
 		),
 	)
 

--- a/custom/distribution/keeper/allocation.go
+++ b/custom/distribution/keeper/allocation.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -31,7 +33,9 @@ func (k Keeper) AllocateTokens(
 	feesCollectedNonRewardDenom := feesCollected.Sub(sdk.NewCoins(feesCollectedRewardDenom))
 
 	// fees that are NOT in the reward denom go directly to the community pool
-	k.FundCommunityPool(ctx, feesCollectedNonRewardDenom, feeCollector.GetAddress())
+	if err := k.FundCommunityPool(ctx, feesCollectedNonRewardDenom, feeCollector.GetAddress()); err != nil {
+		panic(fmt.Sprintf("failed to fund community pool with non-mars tokens: %s", err))
+	}
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/custom/distribution/keeper/allocation_test.go
+++ b/custom/distribution/keeper/allocation_test.go
@@ -1,0 +1,165 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	marsapp "github.com/mars-protocol/hub/app"
+	marsapptesting "github.com/mars-protocol/hub/app/testing"
+)
+
+func setupTest(t *testing.T) (ctx sdk.Context, app *marsapp.MarsApp, valcons sdk.ConsAddress, valoper sdk.ValAddress, user sdk.AccAddress) {
+	app = marsapptesting.MakeMockApp()
+	ctx = app.BaseApp.NewContext(false, tmproto.Header{})
+
+	accts := marsapptesting.MakeRandomAccounts(3)
+	valoper = sdk.ValAddress(accts[0])
+	user = accts[1]
+	feeSender := accts[2]
+
+	pks := simapp.CreateTestPubKeys(1)
+	valPubKey := pks[0]
+
+	fees := sdk.NewCoins(sdk.NewCoin("umars", sdk.NewInt(10000)), sdk.NewCoin("ibc/1234ABCD", sdk.NewInt(20000)))
+
+	// register accounts at the auth module
+	for _, acct := range accts {
+		app.AccountKeeper.SetAccount(ctx, authtypes.NewBaseAccountWithAddress(acct))
+	}
+
+	// set coin balances for user and fee sender
+	app.BankKeeper.InitGenesis(
+		ctx,
+		&banktypes.GenesisState{
+			Params: banktypes.Params{
+				DefaultSendEnabled: true,
+			},
+			Balances: []banktypes.Balance{{
+				Address: user.String(),
+				Coins:   sdk.NewCoins(sdk.NewCoin("umars", sdk.NewInt(10))),
+			}, {
+				Address: feeSender.String(),
+				Coins:   fees,
+			}},
+		},
+	)
+
+	// set bond denom to `umars`
+	stakingParams := app.StakingKeeper.GetParams(ctx)
+	stakingParams.BondDenom = "umars"
+	app.StakingKeeper.SetParams(ctx, stakingParams)
+
+	// create validator with bonded status and 20% commission
+	val, err := stakingtypes.NewValidator(sdk.ValAddress(valoper), valPubKey, stakingtypes.Description{})
+	val.Status = stakingtypes.Bonded
+	val.Commission.CommissionRates = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(2, 1), sdk.NewDecWithPrec(2, 1), sdk.NewDec(0))
+	require.NoError(t, err)
+	require.True(t, val.IsBonded())
+
+	app.StakingKeeper.SetValidator(ctx, val)
+	app.StakingKeeper.SetValidatorByConsAddr(ctx, val)
+	app.StakingKeeper.SetValidatorByPowerIndex(ctx, val)
+	app.StakingKeeper.AfterValidatorCreated(ctx, val.GetOperator()) // required to initialize distr keeper properly
+
+	// user makes delegation to validator
+	newShares, err := app.StakingKeeper.Delegate(
+		ctx,
+		user,
+		sdk.NewInt(10),
+		stakingtypes.Unbonded,
+		val,
+		true, // true means it's a delegation, not a redelegation
+	)
+	require.NoError(t, err)
+	require.True(t, newShares.GT(sdk.ZeroDec()))
+
+	// initialize parameters of the distr module
+	app.DistrKeeper.SetParams(ctx, distrtypes.Params{
+		CommunityTax:        sdk.NewDecWithPrec(3, 1), // 30%
+		BaseProposerReward:  sdk.ZeroDec(),
+		BonusProposerReward: sdk.ZeroDec(), // set to zero for simplicity
+	})
+
+	// fee sender sends coins to the fee collector module account
+	// this simulates the IBC module receives protocol revenue from outposts, and forward them to the fee collector
+	app.BankKeeper.SendCoinsFromAccountToModule(ctx, feeSender, authtypes.FeeCollectorName, fees)
+
+	return ctx, app, sdk.ConsAddress(valPubKey.Address()), valoper, user
+}
+
+func calculateDelegationReward(t *testing.T, ctx sdk.Context, app *marsapp.MarsApp, valAddr sdk.ValAddress, delAddr sdk.AccAddress) sdk.DecCoins {
+	// cache, we don't want to write changes
+	ctx, _ = ctx.CacheContext()
+
+	// query the validator
+	val, found := app.StakingKeeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+
+	// query the delegation
+	del, found := app.StakingKeeper.GetDelegation(ctx, delAddr, valAddr)
+	require.True(t, found)
+
+	// increment the validator ending period
+	endingPeriod := app.DistrKeeper.IncrementValidatorPeriod(ctx, val)
+
+	return app.DistrKeeper.CalculateDelegationRewards(ctx, val, del, endingPeriod)
+}
+
+func TestAllocateTokens(t *testing.T) {
+	ctx, app, valcons, valoper, user := setupTest(t)
+
+	app.DistrKeeper.AllocateTokens(
+		ctx,
+		10,
+		10,
+		valcons,
+		[]abci.VoteInfo{{
+			Validator: abci.Validator{
+				Address: valcons,
+				Power:   10,
+			},
+			SignedLastBlock: true,
+		}},
+	)
+
+	// assert that distr module keeps track of the correct community pool balances
+	// full amount of the 20000 ibc tokens should have been donated to the community pool
+	// among the 10000 umars tokens, 30% or 3000 should have been donated to the community pool
+	communityPool := app.DistrKeeper.GetFeePoolCommunityCoins(ctx)
+	require.Equal(
+		t,
+		sdk.NewDecCoins(sdk.NewDecCoin("ibc/1234ABCD", sdk.NewInt(20000)), sdk.NewDecCoin("umars", sdk.NewInt(3000))),
+		communityPool,
+	)
+
+	// assert that the actual balances of the community pool is correct
+	// since no commission or reward has been withdrawn, the umars amount should be the whole 10000
+	distrModAcctAddr := app.AccountKeeper.GetModuleAccount(ctx, distrtypes.ModuleName)
+	distrModAcctBalances := app.BankKeeper.GetAllBalances(ctx, distrModAcctAddr.GetAddress())
+	require.Equal(
+		t,
+		sdk.NewCoins(sdk.NewCoin("ibc/1234ABCD", sdk.NewInt(20000)), sdk.NewCoin("umars", sdk.NewInt(10000))),
+		distrModAcctBalances,
+	)
+
+	// amoung the 7000 umars after community tax, 20% or 1400 goes to validator commissions
+	commission := app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valoper)
+	require.Equal(t, sdk.NewDecCoins(sdk.NewDecCoin("umars", sdk.NewInt(1400))), commission.Commission)
+
+	// the rest, or 5600 umars goes to staker's reward
+	// NOTE: need to advance to the next block in order for the reward to register
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1) // advance 1 block
+	reward := calculateDelegationReward(t, ctx, app, valoper, user)
+	require.Equal(t, sdk.NewDecCoins(sdk.NewDecCoin("umars", sdk.NewInt(5600))), reward)
+}

--- a/custom/distribution/keeper/keeper.go
+++ b/custom/distribution/keeper/keeper.go
@@ -1,0 +1,43 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+)
+
+// Keeper define the custom distribution module keeper
+//
+// NOTE: Keeper wraps the vanilla distr keeper to inherit most of its functions. However, we replace
+// the fee distribution logic with our own implementation
+type Keeper struct {
+	distrkeeper.Keeper
+
+	// the vanilla distr keeper does not make public the auth and bank keepers, so we have to include
+	// them here
+	authKeeper distrtypes.AccountKeeper
+	bankKeeper distrtypes.BankKeeper
+
+	// same with the fee collector name, have to include it here
+	feeCollectorName string
+}
+
+// NewKeeper returns a custom distr keeper
+//
+// NOTE: Keeper wraps the vanilla distr keeper to inherit most of its functions. However, we replace
+// the fee distribution logic with our own implementation
+func NewKeeper(
+	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
+	ak distrtypes.AccountKeeper, bk distrtypes.BankKeeper, sk distrtypes.StakingKeeper,
+	feeCollectorName string, blockedAddrs map[string]bool,
+) Keeper {
+	return Keeper{
+		Keeper:           distrkeeper.NewKeeper(cdc, key, paramSpace, ak, bk, sk, feeCollectorName, blockedAddrs),
+		authKeeper:       ak,
+		bankKeeper:       bk,
+		feeCollectorName: feeCollectorName,
+	}
+}

--- a/custom/distribution/module.go
+++ b/custom/distribution/module.go
@@ -1,0 +1,42 @@
+package distribution
+
+import (
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	distr "github.com/cosmos/cosmos-sdk/x/distribution"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+
+	"github.com/mars-protocol/hub/custom/distribution/keeper"
+)
+
+// AppModule must implement the `module.AppModule` interface
+var _ module.AppModule = AppModule{}
+
+// AppModule implements an application module for the custom distribution module
+type AppModule struct {
+	distr.AppModule
+
+	keeper keeper.Keeper
+}
+
+// NewAppModule creates a new AppModule object
+func NewAppModule(
+	cdc codec.Codec, keeper keeper.Keeper, accountKeeper distrtypes.AccountKeeper,
+	bankKeeper distrtypes.BankKeeper, stakingKeeper distrtypes.StakingKeeper,
+) AppModule {
+	return AppModule{
+		AppModule: distr.NewAppModule(cdc, keeper.Keeper, accountKeeper, bankKeeper, stakingKeeper),
+		keeper:    keeper,
+	}
+}
+
+// BeginBlocker returns the begin blocker for the custom distr module
+//
+// NOTE: this overwrites the vanilla distr module BeginBlocker with our custom fee distribution logic
+func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
+	BeginBlocker(ctx, req, am.keeper)
+}

--- a/custom/distribution/types/consts.go
+++ b/custom/distribution/types/consts.go
@@ -1,0 +1,9 @@
+package types
+
+// RewardDenom is the denom of the coin to be distributed as staking rewards. All coins that are NOT
+// of this denom goes directly to the community pool.
+//
+// In a later release, this portion of the fees will be directed to a separate "safety fund".
+//
+// TODO: make this a configurable parameter
+const RewardDenom = "umars"

--- a/custom/distribution/types/events.go
+++ b/custom/distribution/types/events.go
@@ -1,0 +1,3 @@
+package types
+
+const EventTypeSafetyFund = "safety_fund"


### PR DESCRIPTION
the objective of this PR is to customize the fee distribution logic of the x/distribution module. we use the same approach of creating a wrapper of the vanilla module, as used in #2 

the new distribution will work in the way as follows. firstly, a "fee collector" contract on the outpost will swap all protocol revenue into mars token and a stablecoin. the mars token is meant to be distributed as staking reward, while the stablecoin is to be deposited into a "safety fund", which can be used to cover bad debt in case of a shortfall event. the proportion of the two coins will be a governance-configurable parameter.

the fee collector contract will use a standard ICS20 fungible token transfer message to send the tokens to the "fee collector" module account on mars hub. (do not confuse! fee collector contract and fee collector module account are two different things)

in the BeginBlocker of the next block, the distribution module will first send all non-mars tokens received in the fee collector module account to the community pool. (we don't have a separate safety fund module implemented yet; so we use the community pool for now)

for mars tokens, a portion goes to the community pool according to the "community tax rate" parameter. the rest will be distributed as staking rewards, split between delegators & validator commissions. 