### PR TITLE
some changes to the marsd command

### DIFF
--- a/cmd/marsd/appcreator.go
+++ b/cmd/marsd/appcreator.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cast"
+
+	"github.com/tendermint/tendermint/libs/log"
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/cosmos/cosmos-sdk/snapshots"
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+
+	marsapp "github.com/mars-protocol/hub/app"
+)
+
+// appCreator is a wrapper for EncodingConfig. This allows us to reuse encodingConfig received by
+// NewRootCmd in both createApp and exportApp
+type appCreator struct{ encodingConfig marsapp.EncodingConfig }
+
+func (ac appCreator) createApp(
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	appOpts servertypes.AppOptions,
+) servertypes.Application {
+	var cache sdk.MultiStorePersistentCache
+
+	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
+		cache = store.NewCommitKVStoreCacheManager()
+	}
+
+	skipUpgradeHeights := make(map[int64]bool)
+	for _, h := range cast.ToIntSlice(appOpts.Get(server.FlagUnsafeSkipUpgrades)) {
+		skipUpgradeHeights[int64(h)] = true
+	}
+
+	pruningOpts, err := server.GetPruningOptionsFromFlags(appOpts)
+	if err != nil {
+		panic(err)
+	}
+
+	snapshotDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
+	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir)
+	if err != nil {
+		panic(err)
+	}
+	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
+	if err != nil {
+		panic(err)
+	}
+
+	var wasmOpts []wasm.Option
+	if cast.ToBool(appOpts.Get("telemetry.enabled")) {
+		wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
+	}
+
+	return marsapp.NewMarsApp(
+		logger, db, traceStore, true, skipUpgradeHeights,
+		cast.ToString(appOpts.Get(flags.FlagHome)),
+		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
+		ac.encodingConfig,
+		appOpts,
+		wasmOpts,
+		baseapp.SetPruning(pruningOpts),
+		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(server.FlagMinGasPrices))),
+		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
+		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(server.FlagHaltHeight))),
+		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(server.FlagHaltTime))),
+		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
+		baseapp.SetInterBlockCache(cache),
+		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
+		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
+		baseapp.SetSnapshotStore(snapshotStore),
+		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
+		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
+	)
+}
+
+func (ac appCreator) exportApp(
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	height int64,
+	forZeroHeight bool,
+	jailWhiteList []string,
+	appOpts servertypes.AppOptions,
+) (servertypes.ExportedApp, error) {
+	homePath, ok := appOpts.Get(flags.FlagHome).(string)
+	if !ok || homePath == "" {
+		return servertypes.ExportedApp{}, errors.New("application home not set")
+	}
+
+	app := marsapp.NewMarsApp(
+		logger,
+		db,
+		traceStore,
+		height == -1, // -1 means no height is provided
+		map[int64]bool{},
+		homePath,
+		uint(1),
+		ac.encodingConfig,
+		appOpts,
+		[]wasm.Option{},
+	)
+
+	if height != -1 {
+		if err := app.LoadHeight(height); err != nil {
+			return servertypes.ExportedApp{}, err
+		}
+	}
+
+	return app.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+}

--- a/cmd/marsd/genaccounts.go
+++ b/cmd/marsd/genaccounts.go
@@ -28,8 +28,8 @@ const (
 	flagVestingAmt   = "vesting-amount"
 )
 
-// AddGenesisAccountCmd returns add-genesis-account cobra Command.
-func AddGenesisAccountCmd(defaultNodeHome string) *cobra.Command {
+// addGenesisAccountCmd returns add-genesis-account cobra Command.
+func addGenesisAccountCmd(defaultNodeHome string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add-account [address_or_key_name] [coin][,[coin]]",
 		Short: "Add a genesis account to genesis.json",

--- a/cmd/marsd/genwasm.go
+++ b/cmd/marsd/genwasm.go
@@ -7,7 +7,7 @@ import (
 	wasmcli "github.com/CosmWasm/wasmd/x/wasm/client/cli"
 )
 
-func AddGenesisWasmMsgCmd(defaultNodeHome string) *cobra.Command {
+func addGenesisWasmMsgCmd(defaultNodeHome string) *cobra.Command {
 	txCmd := &cobra.Command{
 		Use:                        "add-wasm-message",
 		Short:                      "Wasm genesis subcommands",

--- a/cmd/marsd/init.go
+++ b/cmd/marsd/init.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cosmos/go-bip39"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	tmcfg "github.com/tendermint/tendermint/config"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+	tmos "github.com/tendermint/tendermint/libs/os"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmtypes "github.com/tendermint/tendermint/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/input"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+)
+
+type printInfo struct {
+	Moniker  string          `json:"moniker"`
+	ChainID  string          `json:"chain_id"`
+	NodeID   string          `json:"node_id"`
+	AppState json.RawMessage `json:"app_state"`
+}
+
+func displayInfo(moniker, chainID, nodeID string, appState json.RawMessage) error {
+	info := printInfo{moniker, chainID, nodeID, appState}
+
+	out, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(os.Stderr, "%s\n", string(sdk.MustSortJSON(out)))
+
+	return err
+}
+
+// overrideServerConfig replaces some parameters in the Tendermint config received from server context
+// with our custom values.
+//
+// The objective is to slow down the block time to ~30 seconds.
+//
+// For reference, see similar changes made by Celestia: https://github.com/celestiaorg/cosmos-sdk/pull/150
+func overrideServerConfig(cfg *tmcfg.Config) {
+	cfg.Consensus.TimeoutCommit = 25 * time.Second
+	cfg.Consensus.SkipTimeoutCommit = false
+}
+
+// initCmd returns a command that initializes all files needed for Tendermint and th respective application
+func initCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init [moniker] --chain-id [string]",
+		Short: "Initialize private validator, p2p, genesis, and application configuration files",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			cdc := clientCtx.Codec
+
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			config := serverCtx.Config
+			config.Moniker = args[0]
+			config.SetRoot(clientCtx.HomeDir)
+
+			overrideServerConfig(config) // NOTE: here we inject our custom config
+
+			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)
+			if chainID == "" {
+				chainID = fmt.Sprintf("test-chain-%v", tmrand.Str(6))
+			}
+
+			// Get bip39 mnemonic
+			var mnemonic string
+			recover, _ := cmd.Flags().GetBool(genutilcli.FlagRecover)
+			if recover {
+				inBuf := bufio.NewReader(cmd.InOrStdin())
+				value, err := input.GetString("Enter your bip39 mnemonic", inBuf)
+				if err != nil {
+					return err
+				}
+
+				mnemonic = value
+				if !bip39.IsMnemonicValid(mnemonic) {
+					return errors.New("invalid mnemonic")
+				}
+			}
+
+			nodeID, _, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
+			if err != nil {
+				return err
+			}
+
+			genFile := config.GenesisFile()
+			overwrite, _ := cmd.Flags().GetBool(genutilcli.FlagOverwrite)
+
+			if !overwrite && tmos.FileExists(genFile) {
+				return fmt.Errorf("genesis.json file already exists: %v", genFile)
+			}
+
+			appState, err := json.MarshalIndent(mbm.DefaultGenesis(cdc), "", " ")
+			if err != nil {
+				return errors.Wrap(err, "Failed to marshall default genesis state")
+			}
+
+			genDoc := &tmtypes.GenesisDoc{}
+			if _, err := os.Stat(genFile); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+			} else {
+				genDoc, err = tmtypes.GenesisDocFromFile(genFile)
+				if err != nil {
+					return errors.Wrap(err, "Failed to read genesis doc from file")
+				}
+			}
+
+			genDoc.ChainID = chainID
+			genDoc.Validators = nil
+			genDoc.AppState = appState
+
+			if err = genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+				return errors.Wrap(err, "Failed to export gensis file")
+			}
+
+			tmcfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
+
+			return displayInfo(config.Moniker, chainID, nodeID, appState)
+		},
+	}
+
+	cmd.Flags().String(tmcli.HomeFlag, defaultNodeHome, "node's home directory")
+	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
+	cmd.Flags().BoolP(genutilcli.FlagOverwrite, "o", false, "overwrite the genesis.json file")
+	cmd.Flags().Bool(genutilcli.FlagRecover, false, "provide seed phrase to recover existing key instead of creating")
+
+	return cmd
+}

--- a/cmd/marsd/root.go
+++ b/cmd/marsd/root.go
@@ -130,8 +130,8 @@ func genesisCommand(encodingConfig marsapp.EncodingConfig) *cobra.Command {
 			marsapp.DefaultNodeHome,
 		),
 		genutilcli.ValidateGenesisCmd(marsapp.ModuleBasics),
-		AddGenesisAccountCmd(marsapp.DefaultNodeHome),
-		AddGenesisWasmMsgCmd(marsapp.DefaultNodeHome),
+		addGenesisAccountCmd(marsapp.DefaultNodeHome),
+		addGenesisWasmMsgCmd(marsapp.DefaultNodeHome),
 	)
 
 	return cmd

--- a/cmd/marsd/root.go
+++ b/cmd/marsd/root.go
@@ -87,10 +87,10 @@ func NewRootCmd(encodingConfig marsapp.EncodingConfig) *cobra.Command {
 		genesisCommand(encodingConfig),
 		queryCommand(),
 		txCommand(),
+		initCmd(marsapp.ModuleBasics, marsapp.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		config.Cmd(),
 		debug.Cmd(),
-		genutilcli.InitCmd(marsapp.ModuleBasics, marsapp.DefaultNodeHome),
 		keys.Commands(marsapp.DefaultNodeHome),
 		rpc.StatusCommand(),
 	)

--- a/cmd/marsd/root.go
+++ b/cmd/marsd/root.go
@@ -1,20 +1,12 @@
 package main
 
 import (
-	"errors"
-	"io"
 	"os"
-	"path/filepath"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
 	tmcli "github.com/tendermint/tendermint/libs/cli"
-	"github.com/tendermint/tendermint/libs/log"
-	dbm "github.com/tendermint/tm-db"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/debug"
@@ -22,10 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/server"
-	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	"github.com/cosmos/cosmos-sdk/snapshots"
-	"github.com/cosmos/cosmos-sdk/store"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	authcli "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -34,7 +22,6 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 
 	marsapp "github.com/mars-protocol/hub/app"
 )
@@ -186,106 +173,4 @@ func txCommand() *cobra.Command {
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
 
 	return cmd
-}
-
-//--------------------------------------------------------------------------------------------------
-// `appCreator` is a wrapper for `EncodingConfig`. This allows us to reuse `encodingConfig` received
-//  by `NewRootCmd` in `createApp` and `exportApp`
-//--------------------------------------------------------------------------------------------------
-
-type appCreator struct{ encodingConfig marsapp.EncodingConfig }
-
-func (ac appCreator) createApp(
-	logger log.Logger,
-	db dbm.DB,
-	traceStore io.Writer,
-	appOpts servertypes.AppOptions,
-) servertypes.Application {
-	var cache sdk.MultiStorePersistentCache
-
-	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
-		cache = store.NewCommitKVStoreCacheManager()
-	}
-
-	skipUpgradeHeights := make(map[int64]bool)
-	for _, h := range cast.ToIntSlice(appOpts.Get(server.FlagUnsafeSkipUpgrades)) {
-		skipUpgradeHeights[int64(h)] = true
-	}
-
-	pruningOpts, err := server.GetPruningOptionsFromFlags(appOpts)
-	if err != nil {
-		panic(err)
-	}
-
-	snapshotDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
-	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir)
-	if err != nil {
-		panic(err)
-	}
-	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
-	if err != nil {
-		panic(err)
-	}
-
-	var wasmOpts []wasm.Option
-	if cast.ToBool(appOpts.Get("telemetry.enabled")) {
-		wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
-	}
-
-	return marsapp.NewMarsApp(
-		logger, db, traceStore, true, skipUpgradeHeights,
-		cast.ToString(appOpts.Get(flags.FlagHome)),
-		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
-		ac.encodingConfig,
-		appOpts,
-		wasmOpts,
-		baseapp.SetPruning(pruningOpts),
-		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(server.FlagMinGasPrices))),
-		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
-		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(server.FlagHaltHeight))),
-		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(server.FlagHaltTime))),
-		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
-		baseapp.SetInterBlockCache(cache),
-		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
-		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
-		baseapp.SetSnapshotStore(snapshotStore),
-		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
-		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
-	)
-}
-
-func (ac appCreator) exportApp(
-	logger log.Logger,
-	db dbm.DB,
-	traceStore io.Writer,
-	height int64,
-	forZeroHeight bool,
-	jailWhiteList []string,
-	appOpts servertypes.AppOptions,
-) (servertypes.ExportedApp, error) {
-	homePath, ok := appOpts.Get(flags.FlagHome).(string)
-	if !ok || homePath == "" {
-		return servertypes.ExportedApp{}, errors.New("application home not set")
-	}
-
-	app := marsapp.NewMarsApp(
-		logger,
-		db,
-		traceStore,
-		height == -1, // -1 means no height is provided
-		map[int64]bool{},
-		homePath,
-		uint(1),
-		ac.encodingConfig,
-		appOpts,
-		[]wasm.Option{},
-	)
-
-	if height != -1 {
-		if err := app.LoadHeight(height); err != nil {
-			return servertypes.ExportedApp{}, err
-		}
-	}
-
-	return app.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/CosmWasm/wasmd v0.27.0
 	github.com/CosmWasm/wasmvm v1.0.0
 	github.com/cosmos/cosmos-sdk v0.45.6
+	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v3 v3.1.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
 	github.com/golangci/golangci-lint v1.46.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.4.0
@@ -57,7 +59,6 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.7.0 // indirect
 	github.com/confio/ics23/go v0.7.0 // indirect
 	github.com/cosmos/btcutil v1.0.4 // indirect
-	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/iavl v0.17.3 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.11.1 // indirect
@@ -174,7 +175,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.0 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect


### PR DESCRIPTION
the most important change here is that when calling `marsd init`, the `config.toml` file that gets generated has the following customized default parameters:

```toml
[consensus]
timeout_commit = "25s"
```

this slows down block time to ~30 seconds, same as what Celestia does.