### PR TITLE
custom gov module query server

### DIFF
--- a/x/gov/keeper/query_server.go
+++ b/x/gov/keeper/query_server.go
@@ -1,0 +1,79 @@
+package keeper
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+)
+
+type queryServer struct{ k Keeper }
+
+// NewQueryServerImpl creates an implementation of the QueryServer interface for the given keeper
+func NewQueryServerImpl(k Keeper) govtypes.QueryServer {
+	return &queryServer{k}
+}
+
+func (qs queryServer) TallyResult(goCtx context.Context, req *govtypes.QueryTallyResultRequest) (*govtypes.QueryTallyResultResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	if req.ProposalId == 0 {
+		return nil, status.Error(codes.InvalidArgument, "proposal id can not be 0")
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	proposal, ok := qs.k.GetProposal(ctx, req.ProposalId)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "proposal %d doesn't exist", req.ProposalId)
+	}
+
+	var tallyResult govtypes.TallyResult
+
+	switch {
+	case proposal.Status == govtypes.StatusDepositPeriod:
+		tallyResult = govtypes.EmptyTallyResult()
+
+	case proposal.Status == govtypes.StatusPassed || proposal.Status == govtypes.StatusRejected:
+		tallyResult = proposal.FinalTallyResult
+
+	default:
+		// proposal is in voting period
+		_, _, tallyResult = qs.k.Tally(ctx, proposal) // replace with our custom Tally function
+	}
+
+	return &govtypes.QueryTallyResultResponse{Tally: tallyResult}, nil
+}
+
+func (qs queryServer) Proposal(goCtx context.Context, req *govtypes.QueryProposalRequest) (*govtypes.QueryProposalResponse, error) {
+	return qs.k.Proposal(goCtx, req)
+}
+
+func (qs queryServer) Proposals(goCtx context.Context, req *govtypes.QueryProposalsRequest) (*govtypes.QueryProposalsResponse, error) {
+	return qs.k.Proposals(goCtx, req)
+}
+
+func (qs queryServer) Vote(goCtx context.Context, req *govtypes.QueryVoteRequest) (*govtypes.QueryVoteResponse, error) {
+	return qs.k.Vote(goCtx, req)
+}
+
+func (qs queryServer) Votes(goCtx context.Context, req *govtypes.QueryVotesRequest) (*govtypes.QueryVotesResponse, error) {
+	return qs.k.Votes(goCtx, req)
+}
+
+func (qs queryServer) Params(goCtx context.Context, req *govtypes.QueryParamsRequest) (*govtypes.QueryParamsResponse, error) {
+	return qs.k.Params(goCtx, req)
+}
+
+func (qs queryServer) Deposit(goCtx context.Context, req *govtypes.QueryDepositRequest) (*govtypes.QueryDepositResponse, error) {
+	return qs.k.Deposit(goCtx, req)
+}
+
+func (qs queryServer) Deposits(goCtx context.Context, req *govtypes.QueryDepositsRequest) (*govtypes.QueryDepositsResponse, error) {
+	return qs.k.Deposits(goCtx, req)
+}

--- a/x/gov/keeper/query_server_test.go
+++ b/x/gov/keeper/query_server_test.go
@@ -1,0 +1,56 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+)
+
+func TestQueryServer(t *testing.T) {
+	ctx, app, proposal, valoper, voters := setupTest(t, []VotingPower{
+		{Staked: 30, Vesting: 21},
+		{Staked: 49, Vesting: 0},
+	})
+
+	// validator votes yes
+	// voters[0] votes no, overriding the validator's vote
+	// this should results in 49 yes vs 51 no
+	// in comparison, with the vanilla tallying logic, the result would be 49 yes vs 30 no
+	app.GovKeeper.AddVote(ctx, proposal.ProposalId, valoper, govtypes.NewNonSplitVoteOption(govtypes.OptionYes))
+	app.GovKeeper.AddVote(ctx, proposal.ProposalId, voters[0], govtypes.NewNonSplitVoteOption(govtypes.OptionNo))
+
+	queryClient := govtypes.NewQueryClient(&baseapp.QueryServiceTestHelper{
+		Ctx:             ctx,
+		GRPCQueryRouter: app.GRPCQueryRouter(),
+	})
+
+	// query proposal - for this one we use the vanilla logic
+	{
+		res, err := queryClient.Proposal(context.Background(), &govtypes.QueryProposalRequest{ProposalId: proposal.ProposalId})
+		require.NoError(t, err)
+		require.Equal(t, proposal.Content.String(), res.Proposal.Content.String())
+	}
+
+	// query votes - for this one we use the vanilla logic
+	{
+		res, err := queryClient.Vote(context.Background(), &govtypes.QueryVoteRequest{ProposalId: proposal.ProposalId, Voter: voters[0].String()})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(res.Vote.Options))
+		require.Equal(t, govtypes.WeightedVoteOption{Option: govtypes.OptionNo, Weight: sdk.NewDec(1)}, res.Vote.Options[0])
+	}
+
+	// query tally result - this one is replaced with our custom logic
+	{
+		res, err := queryClient.TallyResult(context.Background(), &govtypes.QueryTallyResultRequest{ProposalId: proposal.ProposalId})
+		require.NoError(t, err)
+		require.Equal(t, sdk.NewInt(49), res.Tally.Yes)
+		require.Equal(t, sdk.NewInt(51), res.Tally.No)
+		require.Equal(t, sdk.NewInt(0), res.Tally.NoWithVeto)
+		require.Equal(t, sdk.NewInt(0), res.Tally.Abstain)
+	}
+}

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -168,8 +168,14 @@ func setupTest(t *testing.T, votingPowers []VotingPower) (ctx sdk.Context, app *
 	}
 
 	// create a governance proposal
-	proposal, err = app.GovKeeper.SubmitProposal(ctx, govtypes.NewTextProposal("mock title", "mock description"))
+	//
+	// typically it requires a minimum deposit to make the proposal enter voting period, but here
+	// we forcibly set the status as StatusVotingPeriod.
+	proposal, err = govtypes.NewProposal(govtypes.NewTextProposal("mock title", "mock description"), 1, time.Now(), time.Now())
+	proposal.Status = govtypes.StatusVotingPeriod
 	require.NoError(t, err)
+
+	app.GovKeeper.SetProposal(ctx, proposal)
 
 	return ctx, app, proposal, valoper, voters
 }

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	"github.com/cosmos/cosmos-sdk/x/gov"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	"github.com/mars-protocol/hub/x/gov/keeper"
@@ -40,4 +41,14 @@ func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, ak govtypes.AccountKeep
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
 	EndBlocker(ctx, am.keeper)
 	return []abci.ValidatorUpdate{}
+}
+
+// RegisterServices registers module services.
+//
+// NOTE: this overwrites the vanilla gov module RegisterServices function
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	// msg server - use the vanilla implementation
+	govtypes.RegisterMsgServer(cfg.MsgServer(), govkeeper.NewMsgServerImpl(am.keeper.Keeper))
+	// query server - use our custom implementation
+	govtypes.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }


### PR DESCRIPTION
in order for the `tally_result` query to return the correct result, we need to create our custom gov module query server that uses the custom vote tallying logic.

i don't know why github workflow fails saying i didn't run gofmt, because i did 🤷