### PR TITLE
fast_iavl

### DIFF
--- a/cmd/marsd/appcreator.go
+++ b/cmd/marsd/appcreator.go
@@ -85,6 +85,7 @@ func (ac appCreator) createApp(
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagIAVLFastNode))),
 	)
 }
 

--- a/cmd/marsd/config.go
+++ b/cmd/marsd/config.go
@@ -16,6 +16,11 @@ func initAppConfig() (string, interface{}) {
 	// - if you set srvCfg.MinGasPrices non-empty, validators CAN tweak their own app.toml to override,
 	// or use this default value.
 	cfg.MinGasPrices = "0umars"
+
+	// This ensures that upgrades will use IAVL fast node.
+	// There's a second order effect: archive nodes will take a veritable long-ass time to upgrade.
+	// Reference this history of this file for more information: https://github.com/evmos/evmos/blob/1ca54a4e1c0812933960a9c943a7ab6c4901210d/cmd/evmosd/root.go
+
 	cfg.IAVLDisableFastNode = false
 
 	return template, cfg

--- a/cmd/marsd/config.go
+++ b/cmd/marsd/config.go
@@ -16,6 +16,7 @@ func initAppConfig() (string, interface{}) {
 	// - if you set srvCfg.MinGasPrices non-empty, validators CAN tweak their own app.toml to override,
 	// or use this default value.
 	cfg.MinGasPrices = "0umars"
+	cfg.IAVLDisableFastNode = false
 
 	return template, cfg
 }


### PR DESCRIPTION
This PR for locks fast node in `root.go` -- all nodes will use fast node as default config.
