### PR TITLE
Proposal and vote metadate: type checking and higher length limit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -503,7 +503,20 @@ func NewMarsApp(
 		app.WasmKeeper,
 		initGovRouter(app),
 		app.MsgServiceRouter(),
-		govtypes.DefaultConfig(),
+		// the vanilla gov module by default has a 255-character limit for
+		// proposal metadata, because it assumes proposals will be stored off-
+		// chain and only an IPFS hash will be uploaded on-chain.
+		//
+		// in this, imo, a big mistake! governance proposals are an important
+		// part of a blockchain's history, so their data should be persisted on-
+		// chain. it's not like they will take a huge storage space anyways.
+		//
+		// at Mars we require all proposal metadata to be stored on-chain, and
+		// they must conform to a schema (see the customgov module's README.)
+		// for this to work, we use u64::MAX as the max allowed length.
+		govtypes.Config{
+			MaxMetadataLen: ^uint64(0), // ^ is the bitwise NOT operator
+		},
 	)
 
 	// **** module options ****

--- a/x/gov/README.md
+++ b/x/gov/README.md
@@ -1,8 +1,13 @@
 # Custom Gov
 
-The `customgov` module is wrapper around Cosmos SDK's vanilla `gov` module, inheriting most of its functionalities, but replacing the vote tallying logic with our custom implementation. Namely, tokens locked in the [vesting contract](https://github.com/mars-protocol/hub-periphery/tree/main/contracts/vesting) count towards own's governance voting power.
+The `customgov` module is wrapper around Cosmos SDK's vanilla `gov` module, inheriting most of its functionalities, with two changes:
 
-## Example
+- Replacing the vote tallying logic with our custom implementation. Namely, tokens locked in the [vesting contract](https://github.com/mars-protocol/hub-periphery/tree/main/contracts/vesting) count towards one's governance voting power.
+- Type check proposal and vote metadata.
+
+## Vote tallying logic
+
+Let's illustrate this by an example.
 
 Consider a blockchain with only one validator, as well as two users, Alice and Bob, who have the following amounts of tokens:
 
@@ -15,8 +20,40 @@ Assume the validator votes YES on a proposal, while neither Alice or Bob votes. 
 
 If Alice votes NO, this overrides the validator's voting. The vote will be defeated by 49 tokens voting YES vs 51 tokens voting NO.
 
-## Note
+### A note
 
 Currently, the module assumes the vesting contract is the first contract to be deployed on the chain, i.e. having the code ID of 1 and instance ID of 1. The module uses this info [to derive the contract's address](https://github.com/mars-protocol/hub/blob/2d233fe074b008c49cf26362e1446d888fc81ca0/custom/gov/keeper/tally.go#L12-L15). Developers must make sure this is the case in the chain's genesis state.
 
-For future releases, it may be a good idea to make the contract address a configurable parameter.
+Why not make it a configurable parameter? Because doing so involves modifying gov module's `Params` type definition which breaks a bunch of things, which we prefer not to.
+
+## Proposal metadata
+
+From cosmos-sdk 0.46, governance proposals no longer have a "title" and a "description", but instead a "metadata" which can be an arbitrary string, and by default has a length limit of 255 characters.
+
+This is a big mistake! For two reasons:
+
+- The 255 character limit is there because the module assumes the proposals will be stored off-chain, and only an IPFS hash will be uploaded on-chain. In my opinion, proposals are an important part of a blockchain's history and should be persisted on-chain. In our custom gov module we set the length limit to `u64::MAX`.
+- The module doesn't enforce a type/format/schema of the metadata. This creates problems for webapps, wallets, and block explorers because they won't know how to parse the metadata. At Mars we implement a type-check of the metadata as a part of the handling of `MsgSubmitProposal`.
+
+We require all proposals to come with a non-empty metadata string with this format (defined in TypeScript):
+
+```typescript
+type ProposalMetadata = {
+  title: string;
+  authors: string[];
+  summary?: string;
+  details: string;
+  proposal_forum_url?: string;
+  vote_option_context?: string;
+};
+```
+
+Note that this differs from [what the SDK docs recommands](https://docs.cosmos.network/main/modules/gov#proposal-3) in that `authors` is an array of string instead of a single string, and that a few fields are made optional. We will make a PR to the SDK repo with this change. Hopefully it'll be accepted.
+
+For votes, the metadata can be empty, but if it's non-empty, it must conform to this format:
+
+```typescript
+type VoteMetadata = {
+  justification?: string;
+};
+```

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -1,0 +1,55 @@
+package keeper
+
+import (
+	"context"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
+	"github.com/mars-protocol/hub/x/gov/types"
+)
+
+type msgServer struct{ k Keeper }
+
+// NewMsgServerImpl creates an implementation of the gov v1 MsgServer interface
+// for the given keeper.
+func NewMsgServerImpl(k Keeper) govv1.MsgServer {
+	return &msgServer{k}
+}
+
+func (ms msgServer) SubmitProposal(goCtx context.Context, msg *govv1.MsgSubmitProposal) (*govv1.MsgSubmitProposalResponse, error) {
+	// the metadata string must not be empty. attempt to deserialize it using
+	// the given schema return error if fails.
+	if _, err := types.UnmarshalProposalMetadata(msg.Metadata); err != nil {
+		return nil, sdkerrors.Wrap(types.ErrInvalidMetadata, err.Error())
+	}
+
+	// if metadata is good, we just hand over the rest to the vanilla msgServer
+	return govkeeper.NewMsgServerImpl(ms.k.Keeper).SubmitProposal(goCtx, msg)
+}
+
+func (ms msgServer) Vote(goCtx context.Context, msg *govv1.MsgVote) (*govv1.MsgVoteResponse, error) {
+	// if the metadata string is not empty, attempt to deserialize it using the
+	// given schema. return error if fails
+	if len(msg.Metadata) > 0 {
+		if _, err := types.UnmarshalVoteMetadata(msg.Metadata); err != nil {
+			return nil, sdkerrors.Wrap(types.ErrInvalidMetadata, err.Error())
+		}
+	}
+
+	// if metadata is good, we just hand over the rest to the vanilla msgServer
+	return govkeeper.NewMsgServerImpl(ms.k.Keeper).Vote(goCtx, msg)
+}
+
+func (ms msgServer) ExecLegacyContent(goCtx context.Context, msg *govv1.MsgExecLegacyContent) (*govv1.MsgExecLegacyContentResponse, error) {
+	return govkeeper.NewMsgServerImpl(ms.k.Keeper).ExecLegacyContent(goCtx, msg)
+}
+
+func (ms msgServer) VoteWeighted(goCtx context.Context, msg *govv1.MsgVoteWeighted) (*govv1.MsgVoteWeightedResponse, error) {
+	return govkeeper.NewMsgServerImpl(ms.k.Keeper).VoteWeighted(goCtx, msg)
+}
+
+func (ms msgServer) Deposit(goCtx context.Context, msg *govv1.MsgDeposit) (*govv1.MsgDepositResponse, error) {
+	return govkeeper.NewMsgServerImpl(ms.k.Keeper).Deposit(goCtx, msg)
+}

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -1,0 +1,100 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
+	marsapptesting "github.com/mars-protocol/hub/app/testing"
+
+	"github.com/mars-protocol/hub/x/gov/keeper"
+	"github.com/mars-protocol/hub/x/gov/types"
+)
+
+func TestProposalMetadataTypeCheck(t *testing.T) {
+	ctx, app, _, _, _ := setupTest(t, []VotingPower{{Staked: 1_000_000, Vesting: 0}})
+
+	msgServer := keeper.NewMsgServerImpl(app.GovKeeper)
+
+	// a valid proposal
+	_, err := msgServer.SubmitProposal(ctx, newMsgSubmitProposal(t, `{
+		"title": "Mock Proposal",
+		"authors": ["Larry Engineer <gm@larry.engineer>"],
+		"summary": "Mock proposal for testing purposes",
+		"details": "This is a mock-up proposal for use in the unit tests of Mars Hub's gov module.",
+		"proposal_forum_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		"vote_option_context": "Vote yes if you like this proposal, Vote no if you don't like it."
+	}`))
+	require.NoError(t, err)
+
+	// a valid proposal with missing optional fields
+	// authors can also be an empty array
+	_, err = msgServer.SubmitProposal(ctx, newMsgSubmitProposal(t, `{
+		"title": "Mock Proposal",
+		"authors": [],
+		"details": "This is a mock-up proposal for use in the unit tests of Mars Hub's gov module."
+	}`))
+	require.NoError(t, err)
+
+	// an invalid proposal with mandatory fields missing
+	_, err = msgServer.SubmitProposal(ctx, newMsgSubmitProposal(t, `{
+		"title": "Mock Proposal",
+		"details": "This is a mock-up proposal for use in the unit tests of Mars Hub's gov module."
+	}`))
+	require.Error(t, err, types.ErrInvalidMetadata)
+
+	// extra unexpected fields are not allowed
+	_, err = msgServer.SubmitProposal(ctx, newMsgSubmitProposal(t, `{
+		"title": "Mock Proposal",
+		"authors": ["Larry Engineer <gm@larry.engineer>"],
+		"details": "This is a mock-up proposal for use in the unit tests of Mars Hub's gov module.",
+		"foo": "bar"
+	}`))
+	require.Error(t, err, types.ErrInvalidMetadata)
+
+	// empty metadata string is not allowed
+	_, err = msgServer.SubmitProposal(ctx, newMsgSubmitProposal(t, ""))
+	require.Error(t, err, types.ErrInvalidMetadata)
+}
+
+func TestVoteMetadataTypeCheck(t *testing.T) {
+	ctx, app, _, _, _ := setupTest(t, []VotingPower{{Staked: 1_000_000, Vesting: 0}})
+
+	msgServer := keeper.NewMsgServerImpl(app.GovKeeper)
+
+	// a valid vote
+	_, err := msgServer.Vote(ctx, newMsgVote(`{"justification":"I like the proposal"}`))
+	require.NoError(t, err)
+
+	// a valid proposal with missing optional fields
+	_, err = msgServer.Vote(ctx, newMsgVote(`{}`))
+	require.NoError(t, err)
+
+	// extra unexpected fields are not allowed
+	_, err = msgServer.SubmitProposal(ctx, newMsgSubmitProposal(t, `{"foo":"bar"}`))
+	require.Error(t, err, types.ErrInvalidMetadata)
+
+	// empty metadata string is accepted
+	_, err = msgServer.Vote(ctx, newMsgVote(""))
+	require.NoError(t, err)
+}
+
+func newMsgSubmitProposal(t *testing.T, metadataStr string) *govv1.MsgSubmitProposal {
+	addrs := marsapptesting.MakeRandomAccounts(1)
+	proposer := addrs[0]
+
+	proposal, err := govv1.NewMsgSubmitProposal([]sdk.Msg{}, sdk.NewCoins(), proposer.String(), metadataStr)
+	require.NoError(t, err)
+
+	return proposal
+}
+
+func newMsgVote(metadataStr string) *govv1.MsgVote {
+	addrs := marsapptesting.MakeRandomAccounts(1)
+	voter := addrs[0]
+
+	return govv1.NewMsgVote(voter, 1, govv1.VoteOption_VOTE_OPTION_YES, metadataStr)
+}

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -70,7 +70,7 @@ func TestVoteMetadataTypeCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	// a valid proposal with missing optional fields
-	_, err = msgServer.Vote(ctx, newMsgVote(`{}`))
+	_, err = msgServer.Vote(ctx, newMsgVote("{}"))
 	require.NoError(t, err)
 
 	// extra unexpected fields are not allowed

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -137,8 +137,12 @@ func setupTest(t *testing.T, votingPowers []VotingPower) (ctx sdk.Context, app *
 
 	// create a governance proposal
 	//
-	// typically it requires a minimum deposit to make the proposal enter voting period, but here
-	// we forcibly set the status as StatusVotingPeriod.
+	// typically it requires a minimum deposit to make the proposal enter voting
+	// period, but here we forcibly set the status as StatusVotingPeriod.
+	//
+	// typically we require the proposal's metadata to conform to a schema, but
+	// it's not necessary here as we're not creating the proposal through the
+	// msgServer.
 	proposal, err = govv1.NewProposal([]sdk.Msg{}, 1, "", time.Now(), time.Now())
 	proposal.Status = govv1.StatusVotingPeriod
 	require.NoError(t, err)

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -57,7 +57,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	// msg server - use the vanilla implementation
 	// The changes we've made to execution are in EndBlocker, so the msgServer
 	// doesn't need to be changed.
-	msgServer := govkeeper.NewMsgServerImpl(am.keeper.Keeper)
+	msgServer := keeper.NewMsgServerImpl(am.keeper)
 	govv1beta1.RegisterMsgServer(cfg.MsgServer(), govkeeper.NewLegacyMsgServerImpl(am.accountKeeper.GetModuleAddress(govtypes.ModuleName).String(), msgServer))
 	govv1.RegisterMsgServer(cfg.MsgServer(), msgServer)
 

--- a/x/gov/types/errors.go
+++ b/x/gov/types/errors.go
@@ -6,9 +6,14 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
-// ErrFailedToQueryVesting represents an error where the gov module fails to
-// query the vesting contract.
-//
 // NOTE: latest version (v0.46.0) of the vanilla gov module already registered
 // 2-15, so we start from 16.
-var ErrFailedToQueryVesting = sdkerrors.Register(govtypes.ModuleName, 16, "failed to query vesting contract")
+var (
+	// ErrFailedToQueryVesting represents an error where the gov module fails to
+	// query the vesting contract.
+	ErrFailedToQueryVesting = sdkerrors.Register(govtypes.ModuleName, 16, "failed to query vesting contract")
+
+	// ErrInvalidMetadata represents an error where the metadata (can be one for
+	// a proposal or for a vote) doesn't conform to the required schema.
+	ErrInvalidMetadata = sdkerrors.Register(govtypes.ModuleName, 17, "invalid proposal or vote metadata")
+)

--- a/x/gov/types/metadata.go
+++ b/x/gov/types/metadata.go
@@ -17,7 +17,7 @@ type ProposalMetadata struct {
 
 // VoteMetadata defines the required schema for vote metadata.
 type VoteMetadata struct {
-	Justification *string                `json:"justification,omitempty"`
+	Justification string                 `json:"justification,omitempty"`
 	X             map[string]interface{} `json:"-"` // unexpected fields go here
 }
 
@@ -87,10 +87,6 @@ func UnmarshalVoteMetadata(metadataStr string) (*VoteMetadata, error) {
 	}
 
 	delete(metadata.X, "justification")
-
-	if metadata.Justification == nil {
-		return nil, ErrInvalidMetadata.Wrap("missing field `justification`")
-	}
 
 	if len(metadata.X) > 0 {
 		return nil, ErrInvalidMetadata.Wrap("unexpected field(s)")

--- a/x/gov/types/metadata.go
+++ b/x/gov/types/metadata.go
@@ -6,10 +6,10 @@ import (
 
 // ProposalMetadata defines the required schema for proposal metadata.
 type ProposalMetadata struct {
-	Title             *string                `json:"title"`
-	Authors           *[]string              `json:"authors"`
+	Title             string                 `json:"title"`
+	Authors           []string               `json:"authors"`
 	Summary           string                 `json:"summary,omitempty"`
-	Details           *string                `json:"details"`
+	Details           string                 `json:"details"`
 	ProposalForumURL  string                 `json:"proposal_forum_url,omitempty"`
 	VoteOptionContext string                 `json:"vote_option_context,omitempty"`
 	X                 map[string]interface{} `json:"-"` // unexpected fields go here
@@ -52,7 +52,7 @@ func UnmarshalProposalMetadata(metadataStr string) (*ProposalMetadata, error) {
 	delete(metadata.X, "proposal_forum_url")
 	delete(metadata.X, "vote_option_context")
 
-	if metadata.Title == nil {
+	if metadata.Title == "" {
 		return nil, ErrInvalidMetadata.Wrap("missing field `title`")
 	}
 
@@ -60,7 +60,7 @@ func UnmarshalProposalMetadata(metadataStr string) (*ProposalMetadata, error) {
 		return nil, ErrInvalidMetadata.Wrap("missing field `authors`")
 	}
 
-	if metadata.Details == nil {
+	if metadata.Details == "" {
 		return nil, ErrInvalidMetadata.Wrap("missing field `details`")
 	}
 

--- a/x/gov/types/metadata.go
+++ b/x/gov/types/metadata.go
@@ -1,0 +1,100 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+// ProposalMetadata defines the required schema for proposal metadata.
+type ProposalMetadata struct {
+	Title             *string                `json:"title"`
+	Authors           *[]string              `json:"authors"`
+	Summary           string                 `json:"summary,omitempty"`
+	Details           *string                `json:"details"`
+	ProposalForumURL  string                 `json:"proposal_forum_url,omitempty"`
+	VoteOptionContext string                 `json:"vote_option_context,omitempty"`
+	X                 map[string]interface{} `json:"-"` // unexpected fields go here
+}
+
+// VoteMetadata defines the required schema for vote metadata.
+type VoteMetadata struct {
+	Justification *string                `json:"justification,omitempty"`
+	X             map[string]interface{} `json:"-"` // unexpected fields go here
+}
+
+// UnmarshalProposalMetadata unmarshals a string into ProoposalMetdata.
+//
+// Golang's JSON unmarshal function is retarded. It doesn't check for missing or
+// redundant fields. For example, here in ProposalMetata the "title" field is
+// required. But if we provide a JSON string that doesn't have a title, the
+// json.Unmarshal simply returns metadata.Title = "". Similarly if the JSON
+// string contains an unexpected field, it doesn't throw an error.
+//
+// Therefore we have to implement our own unmarshal function. See:
+//   - Assert required fields are included:
+//     https://stackoverflow.com/questions/19633763/unmarshaling-json-in-go-required-field
+//   - Assert unknown fields are not included:
+//     https://stackoverflow.com/questions/33436730/unmarshal-json-with-some-known-and-some-unknown-field-names
+func UnmarshalProposalMetadata(metadataStr string) (*ProposalMetadata, error) {
+	var metadata ProposalMetadata
+
+	if err := json.Unmarshal([]byte(metadataStr), &metadata); err != nil {
+		return nil, ErrInvalidMetadata.Wrap(err.Error())
+	}
+
+	if err := json.Unmarshal([]byte(metadataStr), &metadata.X); err != nil {
+		return nil, ErrInvalidMetadata.Wrap(err.Error())
+	}
+
+	delete(metadata.X, "title")
+	delete(metadata.X, "authors")
+	delete(metadata.X, "summary")
+	delete(metadata.X, "details")
+	delete(metadata.X, "proposal_forum_url")
+	delete(metadata.X, "vote_option_context")
+
+	if metadata.Title == nil {
+		return nil, ErrInvalidMetadata.Wrap("missing field `title`")
+	}
+
+	if metadata.Authors == nil {
+		return nil, ErrInvalidMetadata.Wrap("missing field `authors`")
+	}
+
+	if metadata.Details == nil {
+		return nil, ErrInvalidMetadata.Wrap("missing field `details`")
+	}
+
+	if len(metadata.X) > 0 {
+		return nil, ErrInvalidMetadata.Wrap("unexpected field(s)")
+	}
+
+	return &metadata, nil
+}
+
+// UnmarshalVoteMetadata unmarshals a string into VoteMetdata.
+//
+// See the comments for UnmarshalProposalMetadata on why we need to define this
+// function instead of using Go's native json.Unmarshal function.
+func UnmarshalVoteMetadata(metadataStr string) (*VoteMetadata, error) {
+	var metadata VoteMetadata
+
+	if err := json.Unmarshal([]byte(metadataStr), &metadata); err != nil {
+		return nil, ErrInvalidMetadata.Wrap(err.Error())
+	}
+
+	if err := json.Unmarshal([]byte(metadataStr), &metadata.X); err != nil {
+		return nil, ErrInvalidMetadata.Wrap(err.Error())
+	}
+
+	delete(metadata.X, "justification")
+
+	if metadata.Justification == nil {
+		return nil, ErrInvalidMetadata.Wrap("missing field `justification`")
+	}
+
+	if len(metadata.X) > 0 {
+		return nil, ErrInvalidMetadata.Wrap("unexpected field(s)")
+	}
+
+	return &metadata, nil
+}


### PR DESCRIPTION
- Use `u64::MAX` as the length limit for proposal and vote metadata, instead of the default 255
- Ensure that these metadata conform to the schema recommended by the SDK docs