### PR TITLE
add `cosmwasm_1_1,cosmwasm_1_2` supported features to wasm module

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -448,7 +448,7 @@ func NewMarsApp(
 		panic("error while reading wasm config: " + err.Error())
 	}
 
-	supportedFeatures := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2"
+	supportedCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2"
 
 	// register wasm bindings of Mars modules here
 	wasmOpts = append(marswasm.RegisterCustomPlugins(&app.DistrKeeper), wasmOpts...)
@@ -470,7 +470,7 @@ func NewMarsApp(
 		app.GRPCQueryRouter(),
 		wasmDir,
 		wasmConfig,
-		supportedFeatures,
+		supportedCapabilities,
 		wasmOpts...,
 	)
 

--- a/app/app.go
+++ b/app/app.go
@@ -448,7 +448,7 @@ func NewMarsApp(
 		panic("error while reading wasm config: " + err.Error())
 	}
 
-	supportedFeatures := "iterator,staking,stargate"
+	supportedFeatures := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2"
 
 	// register wasm bindings of Mars modules here
 	wasmOpts = append(marswasm.RegisterCustomPlugins(&app.DistrKeeper), wasmOpts...)


### PR DESCRIPTION
- Rename `supportedFeatures` to `supportedCapabilities` in accordance with wasmd (in order to avoid confusion with Rust crate features)
- Add `cosmwasm_1_1,cosmwasm_1_2` to the supported capabilities. This allows us to deploy contracts that are compiled with cosmwasm-std's `cosmwasm_1_1` and/or `cosmwasm_1_2` features enabled.