### PR TITLE
allow multiple authorities for envoy

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -544,7 +544,7 @@ func NewMarsApp(
 		app.IBCKeeper.ChannelKeeper,
 		app.ICAControllerKeeper,
 		app.MsgServiceRouter(),
-		authority,
+		[]string{authority},
 	)
 
 	// finally, create gov keeper

--- a/utils/cmp.go
+++ b/utils/cmp.go
@@ -1,0 +1,12 @@
+package utils
+
+// Contains check whether an array of strings contain an element.
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}

--- a/utils/cmp.go
+++ b/utils/cmp.go
@@ -1,6 +1,6 @@
 package utils
 
-// Contains check whether an array of strings contain an element.
+// Contains checks whether an array of strings contains an element.
 func Contains(s []string, str string) bool {
 	for _, v := range s {
 		if v == str {

--- a/x/envoy/keeper/keeper.go
+++ b/x/envoy/keeper/keeper.go
@@ -34,9 +34,9 @@ type Keeper struct {
 	// We use this to dispatch messages upon successful governance proposals.
 	router *baseapp.MsgServiceRouter
 
-	// The account who can execute envoy module messages.
-	// Typically, this should be the x/gov module account.
-	authority string
+	// Accounts who can execute envoy module messages.
+	// Typically, this includes the gov module or other module accounts.
+	authorities []string
 }
 
 // NewKeeper creates a new envoy module keeper.
@@ -44,7 +44,7 @@ func NewKeeper(
 	cdc codec.Codec, accountKeeper authkeeper.AccountKeeper,
 	bankKeeper bankkeeper.Keeper, distrKeeper distrkeeper.Keeper,
 	channelKeeper ibcchannelkeeper.Keeper, icaControllerKeeper icacontrollerkeeper.Keeper,
-	router *baseapp.MsgServiceRouter, authority string,
+	router *baseapp.MsgServiceRouter, authorities []string,
 ) Keeper {
 	// ensure envoy module account is set
 	if addr := accountKeeper.GetModuleAddress(types.ModuleName); addr == nil {
@@ -66,7 +66,7 @@ func NewKeeper(
 		channelKeeper:       channelKeeper,
 		icaControllerKeeper: icaControllerKeeper,
 		router:              router,
-		authority:           authority,
+		authorities:         authorities,
 	}
 }
 

--- a/x/envoy/keeper/msg_server.go
+++ b/x/envoy/keeper/msg_server.go
@@ -9,7 +9,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	icacontrollertypes "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/controller/types"
 	icatypes "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/types"
@@ -119,8 +118,8 @@ func (ms msgServer) RegisterAccount(goCtx context.Context, req *types.MsgRegiste
 func (ms msgServer) SendFunds(goCtx context.Context, req *types.MsgSendFunds) (*types.MsgSendFundsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if req.Authority != ms.k.authority {
-		return nil, govtypes.ErrInvalidSigner.Wrapf("expected %s got %s", ms.k.authority, req.Authority)
+	if !marsutils.Contains(ms.k.authorities, req.Authority) {
+		return nil, types.ErrUnauthorized.Wrapf("address `%s` is not authorized to send this message", req.Authority)
 	}
 
 	owner, portID, err := ms.k.GetOwnerAndPortID()
@@ -211,8 +210,8 @@ func (ms msgServer) SendFunds(goCtx context.Context, req *types.MsgSendFunds) (*
 func (ms msgServer) SendMessages(goCtx context.Context, req *types.MsgSendMessages) (*types.MsgSendMessagesResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if req.Authority != ms.k.authority {
-		return nil, govtypes.ErrInvalidSigner.Wrapf("expected %s got %s", ms.k.authority, req.Authority)
+	if !marsutils.Contains(ms.k.authorities, req.Authority) {
+		return nil, types.ErrUnauthorized.Wrapf("address `%s` is not authorized to send this message", req.Authority)
 	}
 
 	owner := ms.k.GetModuleAddress()

--- a/x/envoy/types/errors.go
+++ b/x/envoy/types/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrInvalidProposalAuthority = errors.Register(ModuleName, 3, "invalid envoy module proposal authority")
 	ErrInvalidProposalMsg       = errors.Register(ModuleName, 4, "invalid envoy module proposal messages")
 	ErrMultihopUnsupported      = errors.Register(ModuleName, 5, "multihop channels are not supported")
+	ErrUnauthorized             = errors.Register(ModuleName, 6, "unauthorized")
 )


### PR DESCRIPTION
Currently only the gov module can send messages to the envoy module. In the future we may want to allows other modules to do this as well, such as x/epoch and x/group.