### PR TITLE
Add Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.19"
+ARG GO_VERSION="1.20"
 ARG RUNNER_IMAGE="gcr.io/distroless/static-debian11"
 
 # --------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION="1.19"
+ARG RUNNER_IMAGE="gcr.io/distroless/static-debian11"
+
+# --------------------------------------------------------
+# Builder
+# --------------------------------------------------------
+
+FROM golang:${GO_VERSION}-alpine as builder
+
+ARG GIT_VERSION
+ARG GIT_COMMIT
+
+RUN apk add --no-cache \
+    ca-certificates \
+    build-base \
+    linux-headers
+
+# Download go dependencies
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    go mod download
+
+# Cosmwasm - Download correct libwasmvm version
+RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
+        -O /lib/libwasmvm_muslc.a && \
+    # verify checksum
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
+    sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep $(uname -m) | cut -d ' ' -f 1)
+
+# Copy the remaining files
+COPY . .
+
+# Build osmosisd binary
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    GOWORK=off go build \
+        -mod=readonly \
+        -tags "netgo,ledger,muslc" \
+        -ldflags \
+            "-X github.com/cosmos/cosmos-sdk/version.Name="mars" \
+            -X github.com/cosmos/cosmos-sdk/version.AppName="marsd" \
+            -X github.com/cosmos/cosmos-sdk/version.Version=${GIT_VERSION} \
+            -X github.com/cosmos/cosmos-sdk/version.Commit=${GIT_COMMIT} \
+            -X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,ledger,muslc' \
+            -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
+        -trimpath \
+        -o /app/build/marsd \
+        /app/cmd/marsd
+
+# --------------------------------------------------------
+# Runner
+# --------------------------------------------------------
+
+FROM ${RUNNER_IMAGE}
+
+COPY --from=builder /app/build/marsd /bin/marsd
+
+ENV HOME /mars
+WORKDIR $HOME
+
+ENTRYPOINT ["marsd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,8 @@ COPY --from=builder /app/build/marsd /bin/marsd
 ENV HOME /mars
 WORKDIR $HOME
 
+EXPOSE 26656
+EXPOSE 26657
+EXPOSE 1317
+
 ENTRYPOINT ["marsd"]

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,44 @@ proto-swagger-gen:
 	@echo "✅ Completed Swagger code generation!"
 
 ###############################################################################
+###                                Docker                                  ###
+###############################################################################
+
+RUNNER_BASE_IMAGE_DISTROLESS := gcr.io/distroless/static-debian11
+RUNNER_BASE_IMAGE_ALPINE := alpine:3.17
+RUNNER_BASE_IMAGE_NONROOT := gcr.io/distroless/static-debian11:nonroot
+
+docker-build:
+	@DOCKER_BUILDKIT=1 docker build \
+		-t mars:local \
+		-t mars:local-distroless \
+		--build-arg GO_VERSION=$(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) \
+		--build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_DISTROLESS) \
+		--build-arg GIT_VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(COMMIT) \
+		-f Dockerfile .
+
+docker-build-distroless: docker-build
+
+docker-build-alpine:
+	@DOCKER_BUILDKIT=1 docker build \
+		-t mars:local-alpine \
+		--build-arg GO_VERSION=$(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) \
+		--build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_ALPINE) \
+		--build-arg GIT_VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(COMMIT) \
+		-f Dockerfile .
+
+docker-build-nonroot:
+	@DOCKER_BUILDKIT=1 docker build \
+		-t mars:local-nonroot \
+		--build-arg GO_VERSION=$(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) \
+		--build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_NONROOT) \
+		--build-arg GIT_VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(COMMIT) \
+		-f Dockerfile .
+
+###############################################################################
 ###                                Linting                                  ###
 ###############################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,6 @@ docker-build:
 		--build-arg GIT_COMMIT=$(COMMIT) \
 		-f Dockerfile .
 
-docker-build-distroless: docker-build
-
 docker-build-alpine:
 	@DOCKER_BUILDKIT=1 $(DOCKER) build \
 		-t mars:local-alpine \
@@ -196,6 +194,8 @@ docker-build-nonroot:
 		--build-arg GIT_VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(COMMIT) \
 		-f Dockerfile .
+
+docker-build-distroless: docker-build
 
 ################################################################################
 ###                                 Linting                                  ###

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ RUNNER_BASE_IMAGE_ALPINE := alpine:3.17
 RUNNER_BASE_IMAGE_NONROOT := gcr.io/distroless/static-debian11:nonroot
 
 docker-build:
-	@DOCKER_BUILDKIT=1 docker build \
+	@DOCKER_BUILDKIT=1 $(DOCKER) build \
 		-t mars:local \
 		-t mars:local-distroless \
 		--build-arg GO_VERSION=$(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) \
@@ -170,7 +170,7 @@ docker-build:
 docker-build-distroless: docker-build
 
 docker-build-alpine:
-	@DOCKER_BUILDKIT=1 docker build \
+	@DOCKER_BUILDKIT=1 $(DOCKER) build \
 		-t mars:local-alpine \
 		--build-arg GO_VERSION=$(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) \
 		--build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_ALPINE) \
@@ -179,7 +179,7 @@ docker-build-alpine:
 		-f Dockerfile .
 
 docker-build-nonroot:
-	@DOCKER_BUILDKIT=1 docker build \
+	@DOCKER_BUILDKIT=1 $(DOCKER) build \
 		-t mars:local-nonroot \
 		--build-arg GO_VERSION=$(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) \
 		--build-arg RUNNER_IMAGE=$(RUNNER_BASE_IMAGE_NONROOT) \


### PR DESCRIPTION
This PR adds a `Dockerfile` and some new commands to the Makefile that allow building a Docker image for Mars.

The Dockerfile is divided in two stages:

1) Builds the `marsd` binary creating a statically link binary with libwasmvm

2) Serves the binary in various runner images, based on the specified `RUNNER_IMAGE` base image.

The Makefile includes the following new commands for building the Docker image:

- `docker-build` - builds the Docker image using the default distroless base image
- `docker-build-distroless` - builds the Docker image using the default distroless base image
- `docker-build-alpine` - builds the Docker image using the Alpine base image
- `docker-build-nonroot` - builds the Docker image using the non-root distroless base image


This is the same docker process we use in Osmosis.

I have used this image to build:

- `osmolabs/mars:1.0.0-rc7`
- `osmolabs/mars:1.0.0`
