### PR TITLE
Update to allow Statesync to download cosmwasm contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ build: enforce-go-version
 #   https://github.com/persistenceOne/incident-reports/blob/main/06-nov-2022_V4_upgrade_halt.md
 enforce-go-version:
 	@echo "🤖 Go version: $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION)"
-ifneq ($(GO_MINOR_VERSION),19)
+ifeq ($(GO_MINOR_VERSION) \>= 19,19)
 	@echo "❌ ERROR: Go version 1.19 is required"
 	@exit 1
 endif

--- a/app/app.go
+++ b/app/app.go
@@ -110,6 +110,7 @@ import (
 	// wasm modules
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmclient "github.com/CosmWasm/wasmd/x/wasm/client"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 
 	// mars modules
 	"github.com/mars-protocol/hub/x/envoy"

--- a/app/app.go
+++ b/app/app.go
@@ -718,6 +718,17 @@ func NewMarsApp(
 		panic(err)
 	}
 
+	// Ensure that state sync delivers the cosmwasm directory as well
+
+	if manager := app.SnapshotManager(); manager != nil {
+		err = manager.RegisterExtensions(
+			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.WasmKeeper),
+		)
+		if err != nil {
+			panic("failed to register snapshot extension: " + err.Error())
+		}
+	}
+
 	// initialize BaseApp
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)


### PR DESCRIPTION
Currently State sync does not download the Cosmwasm contracts on chain.

I checked out v1.0.0.  I had to modify the Makefile to allow the version of go above 19 as well.

Steps I took to test this:
- Created a full node
- Used a working snapshot with wasm dir to get node up
- Set snapshot interval to 100 after caught up #Only to get a quick snapshot with minimal wait and new blocks

Second step:
- Created another full node
- set this node to state sync directly from my testnode above only
- Only the test state sync node is set as a persistent peer, no seeds. Ensuring snapshot comes from me.

Below are the logs/info pertaining to the setup and test.
```
root@localhost:~/hub# make install
fatal: No names found, cannot describe anything.
🤖 Go version: 1.20
🤖 Installing marsd...
go install -mod=readonly -tags 'netgo ledger' -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=mars -X github.com/cosmos/cosmos-sdk/version.AppName=marsd -X github.com/cosmos/cosmos-sdk/version.Version= -X github.com/cosmos/cosmos-sdk/version.Commit=31d3932a226660fa8a30e71aee5bda4941b6b891 -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger" -w -s' -trimpath ./cmd/marsd
go: downloading github.com/notional-labs/wasmd v0.30.0-sdk468
go: downloading github.com/cosmos/cosmos-sdk v0.46.8
go: downloading github.com/informalsystems/tendermint v0.34.24
go: downloading github.com/tendermint/tm-db v0.6.7
go: downloading github.com/CosmWasm/wasmvm v1.1.1
go: downloading google.golang.org/grpc v1.50.1
go: downloading github.com/cosmos/cosmos-proto v1.0.0-alpha8
go: downloading cosmossdk.io/math v1.0.0-beta.4
go: downloading google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e
go: downloading golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
go: downloading github.com/cosmos/gogoproto v1.4.3
go: downloading golang.org/x/net v0.2.0
go: downloading golang.org/x/crypto v0.2.0
go: downloading github.com/cosmos/iavl v0.19.4
go: downloading github.com/btcsuite/btcd v0.22.2
go: downloading github.com/mattn/go-isatty v0.0.16
go: downloading github.com/lib/pq v1.10.6
go: downloading golang.org/x/sys v0.2.0
go: downloading golang.org/x/term v0.2.0
go: downloading golang.org/x/text v0.4.0
go: downloading cloud.google.com/go/storage v1.23.0
go: downloading cloud.google.com/go v0.104.0
go: downloading cloud.google.com/go/iam v0.4.0
go: downloading github.com/googleapis/go-type-adapters v1.0.0
✅ Completed installation!
root@localhost:~/hub# marsd version --long
build_deps:
- cloud.google.com/go@v0.104.0
- cloud.google.com/go/compute/metadata@v0.2.1
- cloud.google.com/go/iam@v0.4.0
- cloud.google.com/go/storage@v1.23.0
- cosmossdk.io/errors@v1.0.0-beta.7
- cosmossdk.io/math@v1.0.0-beta.4
- filippo.io/edwards25519@v1.0.0-rc.1
- github.com/99designs/keyring@v1.2.1
- github.com/ChainSafe/go-schnorrkel@v0.0.0-20200405005733-88cbf1b4c40d
- github.com/CosmWasm/wasmd@v0.30.0 => github.com/notional-labs/wasmd@v0.30.0-sdk468
- github.com/CosmWasm/wasmvm@v1.1.1
- github.com/Workiva/go-datastructures@v1.0.53
- github.com/armon/go-metrics@v0.4.1
- github.com/aws/aws-sdk-go@v1.40.45
- github.com/beorn7/perks@v1.0.1
- github.com/bgentry/go-netrc@v0.0.0-20140422174119-9fd32a8b3d3d
- github.com/bgentry/speakeasy@v0.1.1-0.20220910012023-760eaf8b6816
- github.com/btcsuite/btcd@v0.22.2
- github.com/cenkalti/backoff/v4@v4.1.3
- github.com/cespare/xxhash/v2@v2.1.2
- github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e
- github.com/cockroachdb/apd/v2@v2.0.2
- github.com/coinbase/rosetta-sdk-go@v0.7.9
- github.com/confio/ics23/go@v0.9.0
- github.com/cosmos/btcutil@v1.0.5
- github.com/cosmos/cosmos-proto@v1.0.0-alpha8
- github.com/cosmos/cosmos-sdk@v0.46.8
- github.com/cosmos/go-bip39@v1.0.0
- github.com/cosmos/gogoproto@v1.4.3
- github.com/cosmos/iavl@v0.19.4
- github.com/cosmos/ibc-go/v6@v6.1.0
- github.com/cosmos/ledger-cosmos-go@v0.12.2
- github.com/creachadair/taskgroup@v0.3.2
- github.com/davecgh/go-spew@v1.1.1
- github.com/desertbit/timer@v0.0.0-20180107155436-c41aec40b27f
- github.com/docker/distribution@v2.8.1+incompatible
- github.com/dvsekhvalnov/jose2go@v1.5.0
- github.com/felixge/httpsnoop@v1.0.1
- github.com/fsnotify/fsnotify@v1.6.0
- github.com/go-kit/kit@v0.12.0
- github.com/go-kit/log@v0.2.1
- github.com/go-logfmt/logfmt@v0.5.1
- github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2
- github.com/gogo/gateway@v1.1.0
- github.com/gogo/protobuf@v1.3.3 => github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
- github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da
- github.com/golang/protobuf@v1.5.2
- github.com/golang/snappy@v0.0.4
- github.com/google/btree@v1.1.2
- github.com/google/go-cmp@v0.5.9
- github.com/google/gofuzz@v1.2.0
- github.com/google/orderedcode@v0.0.1
- github.com/google/uuid@v1.3.0
- github.com/googleapis/enterprise-certificate-proxy@v0.2.0
- github.com/googleapis/gax-go/v2@v2.6.0
- github.com/googleapis/go-type-adapters@v1.0.0
- github.com/gorilla/handlers@v1.5.1
- github.com/gorilla/mux@v1.8.0
- github.com/gorilla/websocket@v1.5.0
- github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0
- github.com/grpc-ecosystem/grpc-gateway@v1.16.0
- github.com/gsterjov/go-libsecret@v0.0.0-20161001094733-a6f4afe4910c
- github.com/gtank/merlin@v0.1.1
- github.com/gtank/ristretto255@v0.1.2
- github.com/hashicorp/go-cleanhttp@v0.5.2
- github.com/hashicorp/go-getter@v1.6.1
- github.com/hashicorp/go-immutable-radix@v1.3.1
- github.com/hashicorp/go-safetemp@v1.0.0
- github.com/hashicorp/go-version@v1.6.0
- github.com/hashicorp/golang-lru@v0.5.5-0.20210104140557-80c98217689d
- github.com/hashicorp/hcl@v1.0.0
- github.com/hdevalence/ed25519consensus@v0.0.0-20220222234857-c00d1f31bab3
- github.com/improbable-eng/grpc-web@v0.15.0
- github.com/jmespath/go-jmespath@v0.4.0
- github.com/klauspost/compress@v1.15.11
- github.com/lib/pq@v1.10.6
- github.com/libp2p/go-buffer-pool@v0.1.0
- github.com/magiconair/properties@v1.8.6
- github.com/manifoldco/promptui@v0.9.0
- github.com/mattn/go-colorable@v0.1.13
- github.com/mattn/go-isatty@v0.0.16
- github.com/matttproud/golang_protobuf_extensions@v1.0.2-0.20181231171920-c182affec369
- github.com/mimoo/StrobeGo@v0.0.0-20210601165009-122bf33a46e0
- github.com/minio/highwayhash@v1.0.2
- github.com/mitchellh/go-homedir@v1.1.0
- github.com/mitchellh/go-testing-interface@v1.0.0
- github.com/mitchellh/mapstructure@v1.5.0
- github.com/mtibben/percent@v0.2.1
- github.com/opencontainers/go-digest@v1.0.0
- github.com/pelletier/go-toml/v2@v2.0.5
- github.com/pkg/errors@v0.9.1
- github.com/pmezard/go-difflib@v1.0.0
- github.com/prometheus/client_golang@v1.14.0
- github.com/prometheus/client_model@v0.3.0
- github.com/prometheus/common@v0.37.0
- github.com/prometheus/procfs@v0.8.0
- github.com/rakyll/statik@v0.1.7
- github.com/rcrowley/go-metrics@v0.0.0-20201227073835-cf1acfcdf475
- github.com/regen-network/cosmos-proto@v0.3.1
- github.com/rs/cors@v1.8.2
- github.com/rs/zerolog@v1.27.0
- github.com/spf13/afero@v1.9.2
- github.com/spf13/cast@v1.5.0
- github.com/spf13/cobra@v1.6.1
- github.com/spf13/jwalterweatherman@v1.1.0
- github.com/spf13/pflag@v1.0.5
- github.com/spf13/viper@v1.14.0
- github.com/stretchr/testify@v1.8.1
- github.com/subosito/gotenv@v1.4.1
- github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7
- github.com/tendermint/go-amino@v0.16.0
- github.com/tendermint/tendermint@v0.34.24 => github.com/informalsystems/tendermint@v0.34.24
- github.com/tendermint/tm-db@v0.6.7
- github.com/tidwall/btree@v1.5.0
- github.com/ulikunitz/xz@v0.5.8
- github.com/zondax/hid@v0.9.1
- github.com/zondax/ledger-go@v0.14.1
- go.opencensus.io@v0.23.0
- golang.org/x/crypto@v0.2.0
- golang.org/x/exp@v0.0.0-20220722155223-a9213eeb770e
- golang.org/x/net@v0.2.0
- golang.org/x/oauth2@v0.0.0-20221014153046-6fdb5e3db783
- golang.org/x/sys@v0.2.0
- golang.org/x/term@v0.2.0
- golang.org/x/text@v0.4.0
- golang.org/x/xerrors@v0.0.0-20220907171357-04be3eba64a2
- google.golang.org/api@v0.102.0
- google.golang.org/genproto@v0.0.0-20221024183307-1bc688fe9f3e
- google.golang.org/grpc@v1.50.1
- google.golang.org/protobuf@v1.28.2-0.20220831092852-f930b1dc76e8
- gopkg.in/ini.v1@v1.67.0
- gopkg.in/yaml.v2@v2.4.0
- gopkg.in/yaml.v3@v3.0.1
- nhooyr.io/websocket@v1.8.6
- sigs.k8s.io/yaml@v1.3.0
build_tags: netgo,ledger
commit: 31d3932a226660fa8a30e71aee5bda4941b6b891
cosmos_sdk_version: v0.46.8
go: go version go1.20.1 linux/amd64
name: mars
server_name: marsd
version: ""
```

Golang Lint results:
```
root@localhost:~/hub# golangci-lint run
app/wasm/msg_plugin.go:41:21: SA1019: sdkerrors.Wrapf is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
                        return nil, nil, sdkerrors.Wrapf(err, "invalid custom msg: %s", msg.Custom)
                                         ^
app/wasm/query_plugin.go:16:16: SA1019: sdkerrors.Wrapf is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
                        return nil, sdkerrors.Wrapf(err, "invalid custom query: %s", request)
                                    ^
x/gov/types/errors.go:13:28: SA1019: sdkerrors.Register is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
        ErrFailedToQueryVesting = sdkerrors.Register(govtypes.ModuleName, 17, "failed to query vesting contract")
                                  ^
x/gov/types/errors.go:14:28: SA1019: sdkerrors.Register is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
        ErrInvalidMetadata      = sdkerrors.Register(govtypes.ModuleName, 18, "invalid proposal or vote metadata")
                                  ^
x/gov/types/vesting.go:60:14: SA1019: sdk.Uint is deprecated: Functionality of this package has been moved to it's own module: cosmossdk.io/math (staticcheck)
        VotingPower sdk.Uint `json:"voting_power"`
                    ^
x/gov/keeper/msg_server.go:33:15: SA1019: sdkerrors.Wrap is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
                return nil, sdkerrors.Wrap(types.ErrInvalidMetadata, err.Error())
                            ^
x/gov/keeper/msg_server.go:45:16: SA1019: sdkerrors.Wrap is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
                        return nil, sdkerrors.Wrap(types.ErrInvalidMetadata, err.Error())
                                    ^
x/gov/keeper/vesting.go:23:15: SA1019: sdkerrors.Wrapf is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
                return nil, sdkerrors.Wrapf(types.ErrFailedToQueryVesting, "failed to marshal query request: %s", err)
                            ^
x/incentives/types/errors.go:6:39: SA1019: sdkerrors.Register is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
        ErrFailedRefundToCommunityPool     = sdkerrors.Register(ModuleName, 2, "failed to return funds to community pool")
                                             ^
x/incentives/keeper/schedule.go:30:28: SA1019: sdkerrors.Wrap is deprecated: functionality of this package has been moved to it's own module: (staticcheck)
                return types.Schedule{}, sdkerrors.Wrap(types.ErrFailedWithdrawFromCommunityPool, err.Error())
  
```

Node serving Statesync:
Because the snapshot I used was behind in blocks, the act of catching up allowed me to gain several snapshots without waiting long.

Snapshot dir:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/53557/221284289-29b010fb-ae62-4ea1-8856-6086e500b44b.png">


Wasm Dir:
<img width="527" alt="image" src="https://user-images.githubusercontent.com/53557/221284133-f1fc9665-a6f0-4d7e-a0d4-be3c71c29f1d.png">


Test node that State sync'd:
Discovered snapshot and started process:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/53557/221283923-5ba6ed02-4376-4c5c-a763-9f903e91cc61.png">



Wasm Dir:
<img width="548" alt="image" src="https://user-images.githubusercontent.com/53557/221284030-1850acee-80e2-46df-9645-b30e0604439f.png">


Everything from my end looks good and checks out.  The node continued to stay alive for another 15 minutes before I killed them both.